### PR TITLE
Improve fb filter page

### DIFF
--- a/filter/fb/index.md
+++ b/filter/fb/index.md
@@ -504,16 +504,16 @@ numbers without attack or changing base note can be hidden.
 
 
 
-## Control the frequency of the numbers ##
+## Control the rate of the numbers ##
 
 By default `fb` will calculate number for every single slice (=line).
-You can control this by passing the option `--frequency` with a
-rhythmical value for a note duration (compare with the exclusive
-interpretation `**recip`). With this option you can e.g. tell `fb` to
-only display numbers on every quarter note.
+You can control this by passing the option `--rate` with a rhythmical
+value for a note duration (compare with the exclusive interpretation
+`**recip`). With this option you can e.g. tell `fb` to only display
+numbers on every quarter note.
 
 {% include verovio.html
-	source="frequency"
+	source="rate"
 	humdrum-min-height="465px"
 	humdrum-max-height="465px"
 	humdrum-width="300px"
@@ -523,8 +523,8 @@ only display numbers on every quarter note.
 	tabsize="10"
 	pageWidth="1000"
 %}
-<script type="application/x-humdrum" id="frequency">
-!!!filter: fb -n --frequency 4
+<script type="application/x-humdrum" id="rate">
+!!!filter: fb -n --rate 4
 **kern	**kern	**kern	**kern
 *clefF4	*clefGv2	*clefG2	*clefG2
 *k[f#c#]	*k[f#c#]	*k[f#c#]	*k[f#c#]
@@ -554,7 +554,7 @@ This option is particularly useful when the meter is ternary, e.g.
 *six-eighths* or *nine-eighths*.
 
 {% include verovio.html
-	source="frequency98"
+	source="rate98"
 	humdrum-min-height="460px"
 	humdrum-max-height="460px"
 	humdrum-max-width="260px"
@@ -565,8 +565,8 @@ This option is particularly useful when the meter is ternary, e.g.
 	tabsize="18"
 	pageWidth="1200"
 %}
-<script type="application/x-humdrum" id="frequency98">
-!!!filter: fb -c --frequency 4.
+<script type="application/x-humdrum" id="rate98">
+!!!filter: fb -c --rate 4.
 **kern	**kern
 *k[b-]	*k[b-]
 *M9/8	*M9/8

--- a/filter/fb/index.md
+++ b/filter/fb/index.md
@@ -725,7 +725,7 @@ duplicate numbers.
 
 ## Abbreviated number figures ##
 
-With the `-r` option (`--abbr`) numbers for once slice will get
+With the `-r` option (`--abbreviate`) numbers for once slice will get
 abbreviated to match a reasonable and more or less typical figured
 bass numbering. This option will automatically add `-n -c -s`.
 

--- a/filter/fb/index.md
+++ b/filter/fb/index.md
@@ -260,8 +260,7 @@ exchange.
 
 With the `-l` option (`--lowest`) you can let `fb` find the lowest
 pitch of each slice and use this note as base for all number
-calculations. This options will ignore the potentially passend base
-track with `-b`.
+calculations. This option ignores the base track passed with `-b`.
 
 {% include verovio.html
 	source="lowest"

--- a/filter/fb/index.md
+++ b/filter/fb/index.md
@@ -15,11 +15,11 @@ summary: "Automatically generate figured bass numbers."
 permalink: /filter/fb/index.html
 ---
 
-The `fb` filter analyzes harmonies in `**kern` data and reduces
-them to figured bass like numbers. There are different modes of how
-the numbers can be displayed. This filter supports chords as well as
-spine splits. The reference note for the calculations is in each case
-the lowest pitch within the base track that can be passed with the
+The `fb` filter analyzes harmonies in `**kern` data and reduces them
+to figured bass like numbers. There are different modes of how the
+numbers can be displayed. This filter supports chords as well as spine
+splits. The reference note for the calculations is in each case the
+lowest pitch within the base track that can be passed with the
 `--base` option.
 
 Here is a basic example:
@@ -121,17 +121,17 @@ used in combination with `-i`, 1 is displayed for a unison.
 *-	*-
 </script>
 
-When using the `-c` option the `fb` filter will try to replace the number 2 with
-the number 9 when appropriate. Currently, this feature is not very
-sophisticated.
+When using the `-c` option the `fb` filter will try to replace the
+number 2 with the number 9 when appropriate. Currently, this feature
+is not very sophisticated.
 
 
 
 ## Accidentals ##
 
 By default, `fb` will not display any accidentals. Use the `-a` option
-(`--accidentals`) to display naturals, sharps and flats in front of the
-numbers.
+(`--accidentals`) to display naturals, sharps and flats in front of
+the numbers.
 
 {% include verovio.html
 	source="accidentals_example"
@@ -749,8 +749,8 @@ The current mapping is:
 | 9 3     | 9            |
 
 If numbers for slice don't match a mapping all numbers will be
-displayed as normalized numbers. Note that this mapping may change
-in future.
+displayed as normalized numbers. Note that this mapping may change in
+future.
 
 
 

--- a/filter/fb/index.md
+++ b/filter/fb/index.md
@@ -676,36 +676,41 @@ duplicate numbers.
 **kern	**kern
 *k[b-]	*k[b-]
 *M9/8	*M9/8
-(8FF'L 8C 8F 8A	4.s
-8FF' 8C 8F 8A	.
-8FF'J 8C 8F 8A	.
-8FF'L 8C 8F 8A	4.s
-8GG' 8C 8E 8G	.
-8FF'J 8C 8F 8A	.
-8EE'L 8C 8G 8B-	(8c
-8EE' 8C 8F 8A	8d
-8EE'J 8C 8E 8B-)	8c)
+*^	*
+8F 8A	(8FF'L 8C	4.ryy
+8F 8A	8FF' 8C	.
+8F 8A	8FF'J 8C	.
+8F 8A	8FF'L 8C	4.ryy
+8E 8G	8GG' 8C	.
+8F 8A	8FF'J 8C	.
+8G 8B-	8EE'L 8C	(8c
+8F 8A	8EE' 8C	8d
+8E 8B-	8EE'J 8C)	8c)
+*v	*v	*
 =	=
-(8FF' 8C 8F 8A	[4.a
-8FF' 8C 8F 8A	.
-8FF' 8C 8F 8A	.
-8FF' 8C 8F 8A	8a]
-8FF' 8C 8F 8A	(8b-'
-8FF' 8C 8F 8A	8b')
-8FF' 8C 8F 8A	(8cc
-8FF' 8C 8F 8A	8a)
-8FF' 8C 8F 8A)	8f'
-=	=
-8BB- 8F 8B-	(4.e
-8BB- 8F 8B-	.
-8BB- 8F 8B-	.
-8BB- 8F 8B-	4.d)
-8BB- 8F 8B-	.
-8BB- 8F 8B-	.
-8AA 8C 8F 8B-	(4d
-8AA 8C 8F 8B-	.
-8AA 8C 8F 8B-	8c)
-=	=
+*	*^
+(8FF' 8C 8F	[4.a	8A
+8FF' 8C 8F	.	8A
+8FF' 8C 8F	.	8A
+8FF' 8C 8F	8a]	8A
+8FF' 8C 8F	(8b-'	8A
+8FF' 8C 8F	8b')	8A
+8FF' 8C 8F	(8cc	8A
+8FF' 8C 8F	8a)	8A
+8FF' 8C 8F)	8f'	8A
+=	=	=
+=	=	=
+8BB-	(4.e	8F 8B-
+8BB-	.	8F 8B-
+8BB-	.	8F 8B-
+8BB-	4.d)	8F 8B-
+8BB-	.	8F 8B-
+8BB-	.	8F 8B-
+8AA 8C	(4d	8F 8B-
+8AA 8C	.	8F 8B-
+8AA 8C	8c)	8F 8B-
+=	=	=
+*	*v	*v
 *-	*-
 !!!filter: autobeam
 </script>

--- a/filter/fb/index.md
+++ b/filter/fb/index.md
@@ -79,6 +79,12 @@ interval of the distance between the base voice (default is the first
 
 
 
+## Options ##
+
+{% include filter-options.html file="options.aton" lang="EN" %}
+
+
+
 ## Compound intervals ##
 
 By default, `fb` will display the exact distance between the target

--- a/filter/fb/index.md
+++ b/filter/fb/index.md
@@ -725,7 +725,7 @@ duplicate numbers.
 
 ## Abbreviated number figures ##
 
-With the `-r` option (`--abbreviate`) numbers for once slice will get
+With the `-r` option (`--reduce`) numbers for once slice will get
 abbreviated to match a reasonable and more or less typical figured
 bass numbering. This option will automatically add `-n -c -s`.
 

--- a/filter/fb/index.md
+++ b/filter/fb/index.md
@@ -752,6 +752,62 @@ If numbers for slice don't match a mapping all numbers will be
 displayed as normalized numbers. Note that this mapping may change in
 future.
 
+{% include verovio.html
+	source="reduce"
+	humdrum-min-height="460px"
+	humdrum-max-height="460px"
+	humdrum-max-width="260px"
+	humdrum-min-width="260px"
+	humdrum-width="260px"
+	spacingSystem="0"
+	scale="45"
+	tabsize="18"
+	pageWidth="1200"
+%}
+<script type="application/x-humdrum" id="reduce">
+!!!filter: fb -r -a
+**kern	**kern
+*k[b-]	*k[b-]
+*M9/8	*M9/8
+*^	*
+8F 8A	(8FF'L 8C	4.ryy
+8F 8A	8FF' 8C	.
+8F 8A	8FF'J 8C	.
+8F 8A	8FF'L 8C	4.ryy
+8E 8G	8GG' 8C	.
+8F 8A	8FF'J 8C	.
+8G 8B-	8EE'L 8C	(8c
+8F 8A	8EE' 8C	8d
+8E 8B-	8EE'J 8C)	8c)
+*v	*v	*
+=	=
+*	*^
+(8FF' 8C 8F	[4.a	8A
+8FF' 8C 8F	.	8A
+8FF' 8C 8F	.	8A
+8FF' 8C 8F	8a]	8A
+8FF' 8C 8F	(8b-'	8A
+8FF' 8C 8F	8b')	8A
+8FF' 8C 8F	(8cc	8A
+8FF' 8C 8F	8a)	8A
+8FF' 8C 8F)	8f'	8A
+=	=	=
+=	=	=
+8BB-	(4.e	8F 8B-
+8BB-	.	8F 8B-
+8BB-	.	8F 8B-
+8BB-	4.d)	8F 8B-
+8BB-	.	8F 8B-
+8BB-	.	8F 8B-
+8AA 8C	(4d	8F 8B-
+8AA 8C	.	8F 8B-
+8AA 8C	8c)	8F 8B-
+=	=	=
+*	*v	*v
+*-	*-
+!!!filter: autobeam
+</script>
+
 
 
 ## Aliases ##

--- a/filter/fb/index.md
+++ b/filter/fb/index.md
@@ -570,36 +570,41 @@ This option is particularly useful when the meter is ternary, e.g.
 **kern	**kern
 *k[b-]	*k[b-]
 *M9/8	*M9/8
-(8FF'L 8C 8F 8A	4.s
-8FF' 8C 8F 8A	.
-8FF'J 8C 8F 8A	.
-8FF'L 8C 8F 8A	4.s
-8GG' 8C 8E 8G	.
-8FF'J 8C 8F 8A	.
-8EE'L 8C 8G 8B-	(8c
-8EE' 8C 8F 8A	8d
-8EE'J 8C 8E 8B-)	8c)
+*^	*
+8F 8A	(8FF'L 8C	4.ryy
+8F 8A	8FF' 8C	.
+8F 8A	8FF'J 8C	.
+8F 8A	8FF'L 8C	4.ryy
+8E 8G	8GG' 8C	.
+8F 8A	8FF'J 8C	.
+8G 8B-	8EE'L 8C	(8c
+8F 8A	8EE' 8C	8d
+8E 8B-	8EE'J 8C)	8c)
+*v	*v	*
 =	=
-(8FF' 8C 8F 8A	[4.a
-8FF' 8C 8F 8A	.
-8FF' 8C 8F 8A	.
-8FF' 8C 8F 8A	8a]
-8FF' 8C 8F 8A	(8b-'
-8FF' 8C 8F 8A	8b')
-8FF' 8C 8F 8A	(8cc
-8FF' 8C 8F 8A	8a)
-8FF' 8C 8F 8A)	8f'
-=	=
-8BB- 8F 8B-	(4.e
-8BB- 8F 8B-	.
-8BB- 8F 8B-	.
-8BB- 8F 8B-	4.d)
-8BB- 8F 8B-	.
-8BB- 8F 8B-	.
-8AA 8C 8F 8B-	(4d
-8AA 8C 8F 8B-	.
-8AA 8C 8F 8B-	8c)
-=	=
+*	*^
+(8FF' 8C 8F	[4.a	8A
+8FF' 8C 8F	.	8A
+8FF' 8C 8F	.	8A
+8FF' 8C 8F	8a]	8A
+8FF' 8C 8F	(8b-'	8A
+8FF' 8C 8F	8b')	8A
+8FF' 8C 8F	(8cc	8A
+8FF' 8C 8F	8a)	8A
+8FF' 8C 8F)	8f'	8A
+=	=	=
+=	=	=
+8BB-	(4.e	8F 8B-
+8BB-	.	8F 8B-
+8BB-	.	8F 8B-
+8BB-	4.d)	8F 8B-
+8BB-	.	8F 8B-
+8BB-	.	8F 8B-
+8AA 8C	(4d	8F 8B-
+8AA 8C	.	8F 8B-
+8AA 8C	8c)	8F 8B-
+=	=	=
+*	*v	*v
 *-	*-
 !!!filter: autobeam
 </script>

--- a/filter/fb/options.aton
+++ b/filter/fb/options.aton
@@ -1,0 +1,100 @@
+@@BEGIN: OPTIONS
+@TOOL: fb
+
+@@BEGIN: OPTION
+@DEFINITION: c=b
+@ARGUMENT:
+@SUMMARY: Output reasonable figured bass numbers within octave
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: a=b
+@ARGUMENT:
+@SUMMARY: Display accidentals in front of the numbers
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: 3=b
+@ARGUMENT:
+@SUMMARY: Hide number 3 if it has an accidental
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: m=b
+@ARGUMENT:
+@SUMMARY: Show negative numbers
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: l=b
+@ARGUMENT:
+@SUMMARY: Use lowest note as base note
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: b=i:1
+@ARGUMENT:
+@SUMMARY: Number of the base kern track (compare with -k)
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: k=s
+@ARGUMENT:
+@SUMMARY: Process only the specified kern spines
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: s=s
+@ARGUMENT:
+@SUMMARY: Process only the specified spines
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: above=b
+@ARGUMENT:
+@SUMMARY: Show numbers above the staff (**fba)
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: i=b
+@ARGUMENT:
+@SUMMARY: Display numbers under their voice instead of under the base staff
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: t=b
+@ARGUMENT:
+@SUMMARY: Hide numbers without attack or changing base (needs -i)
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: rate=s:
+@ARGUMENT:
+@SUMMARY: Rate to display the numbers (use a **recip value, e.g. 4, 4.)
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: o=b
+@ARGUMENT:
+@SUMMARY: Sort figured bass numbers by size
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: n=b
+@ARGUMENT:
+@SUMMARY: Remove number 8 and doubled numbers; adds -co
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: r=b
+@ARGUMENT:
+@SUMMARY: Use abbreviated figures; adds -nco
+@@END: OPTION
+
+@@BEGIN: OPTION
+@DEFINITION: f=b
+@ARGUMENT:
+@SUMMARY: Shortcut for -acorn3
+@@END: OPTION
+
+@@END: OPTIONS


### PR DESCRIPTION
Closes https://github.com/humdrum-tools/vhv-documentation/issues/20.

* Fix typos
* Add options table
* Update Mendelssohn score with spine split and fix hidden rest
* Rename `--rate`
* Rename `--reduce`
* Add example for `--reduce`

> Note that verovio on the fb documentation page will crash because of this change (at least it did on localhost). I will wait with merging this PR until humlib is updated in the verovio repo.